### PR TITLE
fix for crash in listprojects

### DIFF
--- a/lib/ctt/listprojects.py
+++ b/lib/ctt/listprojects.py
@@ -34,7 +34,7 @@ class ListProjects(object):
 
 
     @classmethod
-    def print_projects():
+    def print_projects(cls):
         for project in cls.list_projects():
             print(project)
 


### PR DESCRIPTION
[36] ozn@deboz:~/software/ctt  [master]  $ ctt listprojects
Traceback (most recent call last):
  File "/usr/local/bin/ctt", line 5, in <module>
    pkg_resources.run_script('ctt==0.9', 'ctt')
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 507, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 1273, in run_script
    exec(compile(open(script_filename).read(), script_filename, 'exec'), namespace, namespace)
  File "/usr/local/lib/python3.3/dist-packages/ctt-0.9-py3.3.egg/EGG-INFO/scripts/ctt", line 119, in <module>
    parse_argv(sys.argv[1:], ctt.VERSION)
  File "/usr/local/lib/python3.3/dist-packages/ctt-0.9-py3.3.egg/EGG-INFO/scripts/ctt", line 95, in parse_argv
    args.func(args)
  File "/usr/local/lib/python3.3/dist-packages/ctt-0.9-py3.3.egg/lib/ctt/listprojects.py", line 33, in commandline
    cls.print_projects()
TypeError: print_projects() takes 0 positional arguments but 1 was given
