### PR TITLE
Add report project name globbing.

### DIFF
--- a/lib/ctt/report.py
+++ b/lib/ctt/report.py
@@ -30,6 +30,7 @@ import os
 import os.path
 import re
 import sys
+import glob
 
 import ctt
 import ctt.listprojects
@@ -63,7 +64,10 @@ class Report(object):
             projects=ctt.listprojects.ListProjects.list_projects()
 
         else:
-            projects=args.project
+            projects = []
+            for x in args.project:
+                fnames = glob.glob(os.path.join(ctt.ctt_dir(), x))
+                projects.extend(fnames)
 
         total_time = 0
         for project in projects:


### PR DESCRIPTION
Hi!

I added globbing for project names for ctt report.
With this ctt can be used as the following (take note to the project argument passed to ctt):
**Using shell globing:**
```
$ bin/ctt report -d ~/.ctt/test*
Namespace(all=False, debug=True, end=None, func=<bound method type.commandline of <class 'ctt.report.Report'>>, ignore_case=False, output_format='{start_datetime} ({delta}): {comment}', project=['/cygdrive/c/Users/dpolja/.ctt/test-1', '/cygdrive/c/Users/dpolja/.ctt/test-2'], regexp=None, start=None, verbose=False)
Dirname: 2016-03-25-0805
Recording: 2016-03-25-0805: 5.736573
Report for /cygdrive/c/Users/dpolja/.ctt/test-1 between 2016-03-01 00:00:00 and 2016-03-31 23:59:59
2016-03-25-0805 (0:00:05): test 1
Adding 5.736573 to 0 time...
Dirname: 2016-03-25-0805
Recording: 2016-03-25-0805: 3.387339
Report for /cygdrive/c/Users/dpolja/.ctt/test-2 between 2016-03-01 00:00:00 and 2016-03-31 23:59:59
2016-03-25-0805 (0:00:03): test 2
Adding 3.387339 to 0 time...
Total time tracked: 0h 0m 9.123912s.

```
**Using ctt's globbing:**
```
$ bin/ctt report -d test*
Namespace(all=False, debug=True, end=None, func=<bound method type.commandline of <class 'ctt.report.Report'>>, ignore_case=False, output_format='{start_datetime} ({delta}): {comment}', project=['test*'], regexp=None, start=None, verbose=False)
Dirname: 2016-03-25-0805
Recording: 2016-03-25-0805: 5.736573
Report for /cygdrive/c/Users/dpolja/.ctt/test-1 between 2016-03-01 00:00:00 and 2016-03-31 23:59:59
2016-03-25-0805 (0:00:05): test 1
Adding 5.736573 to 0 time...
Dirname: 2016-03-25-0805
Recording: 2016-03-25-0805: 3.387339
Report for /cygdrive/c/Users/dpolja/.ctt/test-2 between 2016-03-01 00:00:00 and 2016-03-31 23:59:59
2016-03-25-0805 (0:00:03): test 2
Adding 3.387339 to 0 time...
Total time tracked: 0h 0m 9.123912s.

```