### PR TITLE
Report project name as file path basename.

### DIFF
--- a/lib/ctt/report.py
+++ b/lib/ctt/report.py
@@ -159,8 +159,9 @@ class Report(object):
         self.list_entries()
 
     def header(self):
+        project_name = os.path.basename(self.project)
         print("Report for %s between %s and %s" %
-            (self.project, self.start_date, self.end_date))
+            (project_name, self.start_date, self.end_date))
 
     @staticmethod
     def summary(total_time):


### PR DESCRIPTION
Report project name as file path basename (remove directory path prefix).
Now it reports projects like:
```
$ python3 scripts/ctt report -a
Report for foo between 2016-04-01 00:00:00 and 2016-04-30 23:59:59
2016-04-02-2110 (0:00:04): foo
Report for test-1 between 2016-04-01 00:00:00 and 2016-04-30 23:59:59
2016-04-02-2109 (0:00:02): test 1
Report for test-2 between 2016-04-01 00:00:00 and 2016-04-30 23:59:59
2016-04-02-2109 (0:00:02): test 2
Report for test-3 between 2016-04-01 00:00:00 and 2016-04-30 23:59:59
2016-04-02-2109 (0:00:01): test 3
Total time tracked: 0h 0m 12.096428s.
```