### PR TITLE
Fix error when called without args.

### DIFF
--- a/scripts/ctt
+++ b/scripts/ctt
@@ -92,8 +92,10 @@ def parse_argv(argv, version):
     log.debug(args)
 
     try:
-        args.func(args)
-
+        if hasattr(args, "func"):
+            args.func(args)
+        else:
+            parser['main'].print_help()
     except ctt.Error as e:
         log.error(e)
         sys.exit(1)


### PR DESCRIPTION
Fixed error when ctt is called without args, i.e. remove error:
'Namespace' object has no attribute 'func'.