### PR TITLE
Summary option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+__pycache__/
 lib/ctt/__pycache__/
+*.pyc
+
+# -vim
+.*.swp
 
 # Manpages
 *.1

--- a/changelog
+++ b/changelog
@@ -4,6 +4,12 @@ Changelog
 	* Changes are always commented with their author in (braces)
 	* Exception: No braces means author == Nico Schottelius
 
+Next:
+	* Added -s, --summary option (Darko Poljak)
+	* No args error (Darko Poljak)
+	* Report project name as file path basename (Darko Poljak)
+	* Report globbing (Darko Poljak)
+
 1.0: 2014-07-01
 	* Added installer (Oz Nahum)
 	* Bugfix in listprojects (Oz Nahum)

--- a/lib/ctt/report.py
+++ b/lib/ctt/report.py
@@ -192,7 +192,7 @@ class Report(object):
                 log.debug("Skipping: %s" % dirname)
 
     def report(self, summary=False):
-        return self.list_entries(summary)
+        return self.list_entries()
 
     def header(self):
         project_name = os.path.basename(self.project)
@@ -239,15 +239,11 @@ class Report(object):
         return report
 
 
-    def list_entries(self, summary=False):
+    def list_entries(self):
         """Return total time tracked"""
 
         entries = {}
-        if summary:
-            time_keys = self._report_db.keys()
-        else:
-            time_keys = sorted(self._report_db.keys())
-
+        time_keys = self._report_db.keys()
         for time in time_keys:
             entry = self._report_db[time]
             report = self._get_report_entry(time, entry)

--- a/scripts/ctt
+++ b/scripts/ctt
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # 2012-2015 Nico Schottelius (nico-ctt at schottelius.org)
+# 2016 Darko Poljak (darko.poljak at gmail.com)
 #
 # This file is part of ctt.
 #
@@ -78,6 +79,7 @@ def parse_argv(argv, version):
     parser['report'].add_argument("-i", "--ignore-case", help="ignore case distinctions", action="store_true")
     parser['report'].add_argument("-f", "--format", help="output format (default: %s)" % ctt.REPORTFORMAT, 
         default=ctt.REPORTFORMAT, dest="output_format")
+    parser['report'].add_argument("-s", "--summary", help="hie project names and list time entries in chronological order", action="store_true")
 
     #parser['track'].add_argument("-t", "--tag", help="Add tags",
     #    action="store_true")


### PR DESCRIPTION
I added an -s, --summary option that hides the project names
and just lists all time entries in chronological order,
even if entries are coming from multiple projects.
