### PR TITLE
Fix typo and man.text.

### DIFF
--- a/ctt.text
+++ b/ctt.text
@@ -16,8 +16,8 @@ ctt listprojects [-h] [-d] [-v]
 
 ctt track [-h] [-d] [-v] [--sd START] [--ed END] [-n] project
 
-ctt report [-h] [-d] [-v] [--sd START] [--ed END] [-e REGEXP] [-i]
-           [-f OUTPUT_FORMAT]
+ctt report [-h] [-d] [-v] [--sd START] [--ed END] [-a] [-e REGEXP] [-i]
+           [-f OUTPUT_FORMAT] [-s]
            project
 
 
@@ -70,12 +70,16 @@ Available parameters:
     start date (default: first of this month, format: Y-m-d)
 --ed END, --end END::
     end date (default: last of this month, format: Y-m-d)
+-a, --all::
+    List entries for all projects
 -e REGEXP, --regexp REGEXP::
     regular expression to match
 -i, --ignore-case::
     ignore case distinctions
 -f OUTPUT_FORMAT, --format OUTPUT_FORMAT::
     output format (default: {start_datetime} ({delta}): {comment})
+-s, --summary::
+    hide project names and list time entries in chronological order
 
 Output format may reference the following fields:
 

--- a/scripts/ctt
+++ b/scripts/ctt
@@ -79,7 +79,7 @@ def parse_argv(argv, version):
     parser['report'].add_argument("-i", "--ignore-case", help="ignore case distinctions", action="store_true")
     parser['report'].add_argument("-f", "--format", help="output format (default: %s)" % ctt.REPORTFORMAT, 
         default=ctt.REPORTFORMAT, dest="output_format")
-    parser['report'].add_argument("-s", "--summary", help="hie project names and list time entries in chronological order", action="store_true")
+    parser['report'].add_argument("-s", "--summary", help="hide project names and list time entries in chronological order", action="store_true")
 
     #parser['track'].add_argument("-t", "--tag", help="Add tags",
     #    action="store_true")


### PR DESCRIPTION
Hello!

Fixed typo in report.py.
Updated man.text with missing new options(-a, -s).